### PR TITLE
Update KKPDiffuse.cginc

### DIFF
--- a/Shaders/Item/KKPItemFrag.cginc
+++ b/Shaders/Item/KKPItemFrag.cginc
@@ -36,11 +36,13 @@ fixed4 frag (Varyings i, int faceDir : VFACE) : SV_Target{
 
 	float2 colorUV = i.uv0 * _ColMask_ST.xy + _ColMask_ST.zw;
 	float4 colorMask = SAMPLE_TEX2D_SAMPLER(_ColMask, _MainTex, colorUV);
-
+	
 	float3 color = _Col0;
+	float3 white = float3(1.0, 1.0, 1.0);
 	color = colorMask.r * (_Col1 - color) + color;
 	color = colorMask.g * (_Col2 - color) + color;
 	color = colorMask.b * (_Col3 - color) + color;
+	color = (1.0-colorMask.a) * (white - color) + color;
 	float3 diffuse = mainTex * color;
 
 	float3 shadingAdjustment = ShadeAdjust(diffuse);

--- a/Shaders/Skin/KKPDiffuse.cginc
+++ b/Shaders/Skin/KKPDiffuse.cginc
@@ -181,9 +181,11 @@ float3 GetDiffuse(Varyings i){
 	float4 colorMask = SAMPLE_TEX2D_SAMPLER(_ColMask, _MainTex, colorUV);
 	
 	float3 color = _Col0;
+	float3 white = float3(1.0, 1.0, 1.0);
 	color = colorMask.r * (_Col1 - color) + color;
 	color = colorMask.g * (_Col2 - color) + color;
 	color = colorMask.b * (_Col3 - color) + color;
+	color = (1.0-colorMask.a) * (white - color) + color;
 	
 	mainTex.rgb = mainTex.rgb * color;
 	


### PR DESCRIPTION
Utilized the Alpha channel of the Color Map to blend between MainTex and Color Map colors.
The reason is to allow the black colors in a color map to be used as an additional color.

03/10 Update: Updated to include Items.